### PR TITLE
Upgrade to .NET 8

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 7.0.x
+        dotnet-version: 8.0.x
     - name: Run automated unit and integration tests
       run: dotnet test PipelinesToActions/PipelinesToActions.Tests/PipelinesToActions.Tests.csproj --configuration Debug -e:CollectCoverage=true -e:CoverletOutput=TestResults/ -e:CoverletOutputFormat=lcov 
     - run: |
@@ -45,7 +45,7 @@ jobs:
       uses: actions/upload-artifact@v3
       with:
         name: webapp
-        path: PipelinesToActions/PipelinesToActions/bin/Release/net7.0/publish
+        path: PipelinesToActions/PipelinesToActions/bin/Release/net8.0/publish
  
  
   sonarCloud:
@@ -57,7 +57,7 @@ jobs:
         uses: samsmithnz/SamsDotNetSonarCloudAction@v2.0.1
         with:
           projects: 'PipelinesToActions/PipelinesToActions/PipelinesToActionsWeb.csproj,PipelinesToActions/PipelinesToActions.Tests/PipelinesToActions.Tests.csproj'
-          dotnet-version: '7.0.x'
+          dotnet-version: '8.0.x'
           sonarcloud-organization: samsmithnz-github
           sonarcloud-project: samsmithnz_AzurePipelinesToGitHubActionsConverterWeb
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/GitVersion.yml
+++ b/GitVersion.yml
@@ -1,1 +1,1 @@
-next-version: 1.2.0
+next-version: 1.3.0

--- a/PipelinesToActions/PipelinesToActions.Tests/PipelinesToActions.Tests.csproj
+++ b/PipelinesToActions/PipelinesToActions.Tests/PipelinesToActions.Tests.csproj
@@ -13,7 +13,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
     <PackageReference Include="MSTest.TestAdapter" Version="3.1.1" />
     <PackageReference Include="MSTest.TestFramework" Version="3.1.1" />
     <PackageReference Include="coverlet.collector" Version="6.0.0">

--- a/PipelinesToActions/PipelinesToActions.Tests/PipelinesToActions.Tests.csproj
+++ b/PipelinesToActions/PipelinesToActions.Tests/PipelinesToActions.Tests.csproj
@@ -1,10 +1,9 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 

--- a/PipelinesToActions/PipelinesToActions/PipelinesToActionsWeb.csproj
+++ b/PipelinesToActions/PipelinesToActions/PipelinesToActionsWeb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ApplicationInsightsResourceId>/subscriptions/65b8d298-e5bd-4735-912e-8b9c510c4e00/resourcegroups/PipelinesToActions/providers/microsoft.insights/components/PipelinesToActions-AppInsights</ApplicationInsightsResourceId>
     <Version>1.0.0.0</Version>
     <Deterministic>false</Deterministic>


### PR DESCRIPTION
This pull request includes updates to various files related to the `PipelinesToActions` project, including updating the target framework and dependencies, upgrading the .NET version used in GitHub Actions, and updating the version number in `GitVersion.yml`. The most important changes include updating the target framework for the `PipelinesToActionsWeb.csproj` project and upgrading the .NET version used in the `main.yml` and `codeql-analysis.yml` workflows.

Main interface changes:

* <a href="diffhunk://#diff-21aa8f01c1b4c48de169f1c3c29d3d49953cd933d3abcac5acda3b7021c4ec9fL4-R4">`PipelinesToActions/PipelinesToActions/PipelinesToActionsWeb.csproj`</a>: Updated target framework from `net7.0` to `net8.0`.
* <a href="diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L60-R60">`.github/workflows/main.yml`</a>: Upgraded the .NET version to 8.0.x in GitHub Actions and changed the path to the publish directory for the webapp artifact. <a href="diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L60-R60">[1]</a> <a href="diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L29-R29">[2]</a> <a href="diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3L48-R48">[3]</a>
* <a href="diffhunk://#diff-63bd641104d10e25f141d518a16b22a151d125e12701df2f9e79734b23b90188L42-R42">`.github/workflows/codeql-analysis.yml`</a>: Upgraded the .NET version used in the GitHub Action from 7.0.x to 8.0.x in the codeql-analysis workflow.

Configuration improvements:

* <a href="diffhunk://#diff-1b800222c322c27580a65856212fc4fd9bf1128603cb0864b2e85f6f22b567c9L1-R1">`GitVersion.yml`</a>: Updated version number from `1.2.0` to `1.3.0`.

Dependency updates:

* <a href="diffhunk://#diff-43840d8816c346d59ddeccf87e76398e4e4eacbf86d6e3825897fac2b5321ccbL16-R15">`PipelinesToActions/PipelinesToActions.Tests/PipelinesToActions.Tests.csproj`</a>: Updated dependencies and target framework version. <a href="diffhunk://#diff-43840d8816c346d59ddeccf87e76398e4e4eacbf86d6e3825897fac2b5321ccbL16-R15">[1]</a> <a href="diffhunk://#diff-43840d8816c346d59ddeccf87e76398e4e4eacbf86d6e3825897fac2b5321ccbL4-L7">[2]</a>